### PR TITLE
replace jieba with jieba3

### DIFF
--- a/cjk_textwrap/cjk_textwrap.py
+++ b/cjk_textwrap/cjk_textwrap.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
-import jieba
+import jieba3
 # modified from Python 3.10's textwrap.py
 # https://github.com/python/cpython/blob/3.10/Lib/textwrap.py
 
@@ -15,6 +15,7 @@ __all__ = ['TextWrapper', 'wrap', 'fill', 'dedent', 'indent', 'shorten']
 # some Unicode spaces (like \u00a0) are non-breaking whitespaces.
 _whitespace = '\t\n\x0b\x0c\r '
 
+jieba_tokenizer = jieba3.jieba3()
 
 class TextWrapper:
     """
@@ -170,7 +171,7 @@ class TextWrapper:
         """_split(text : string) -> [string]
         core function, split cjk sentence into indivisible chunks.
         """
-        chunks = list(jieba.cut(text, cut_all=False))
+        chunks = list(jieba_tokenizer.cut_text(text))
         return chunks
 
     def _split(self, text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cjk-textwrap"
-version = "0.1.0"
+version = "0.2.0"
 description = "A flexible textwrapper for CJK string"
 authors = ["Carbene <hyikerhu0212@gmail.com>"]
 license = "MIT"
@@ -13,13 +13,13 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-jieba = "^0.42.1"
+python = "^3.10"
+jieba3 = "^1.0.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
 autopep8 = "^1.6.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.8.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
jieba has not been maintained for a long time. (last update from 5 years ago) ; and not work in Python 3.12+ .

This PR replace jieba with new jieba3 for Chinese text segmentation. 

all tests passed.